### PR TITLE
Add missing link to pass

### DIFF
--- a/doc/src/index.md
+++ b/doc/src/index.md
@@ -65,4 +65,6 @@ Those are namely
 
 [wot]: https://www.gnupg.org/gph/en/manual/x547.html
 [gpgme]: https://github.com/johnschug/rust-gpgme
+[pass]: https://www.passwordstore.org
+
    


### PR DESCRIPTION
Link to `pass` homepage was missing